### PR TITLE
Add custom waypoints for RSS and GPP to Sub-orbital contract

### DIFF
--- a/GameData/ContractPacks/Tourism/SubOrbital.cfg
+++ b/GameData/ContractPacks/Tourism/SubOrbital.cfg
@@ -426,6 +426,19 @@ CONTRACT_TYPE
 
             hidden = @/selectedWaypoint != 8
 		}
+		
+		WAYPOINT:NEEDS[GPP]
+		{
+			name = Mount Iodos
+            icon = ContractPacks/Tourism/Icons/Kerbal
+
+            // The location
+            latitude = 25.91019
+            longitude = -60.12251
+            altitude = @/targetBody.AtmosphereAltitude()
+
+            hidden = @/selectedWaypoint != 9
+		}
     }
 
     BEHAVIOUR

--- a/GameData/ContractPacks/Tourism/SubOrbital.cfg
+++ b/GameData/ContractPacks/Tourism/SubOrbital.cfg
@@ -416,7 +416,7 @@ CONTRACT_TYPE
 		
 		WAYPOINT:NEEDS[GPP]
 		{
-			name = Mount Maximus
+			name = Mount Cilos
             icon = ContractPacks/Tourism/Icons/Kerbal
 
             // The location

--- a/GameData/ContractPacks/Tourism/SubOrbital.cfg
+++ b/GameData/ContractPacks/Tourism/SubOrbital.cfg
@@ -134,7 +134,8 @@ CONTRACT_TYPE
             hidden = @/selectedWaypoint != 1
         }
 
-        WAYPOINT
+		// Kerbin specific waypoints
+        WAYPOINT:NEEDS[!RealSolarSystem,!GPP]
         {
             name = The Great Desert
             icon = ContractPacks/Tourism/Icons/Kerbal
@@ -147,7 +148,7 @@ CONTRACT_TYPE
             hidden = @/selectedWaypoint != 2
         }
 
-        WAYPOINT
+        WAYPOINT:NEEDS[!RealSolarSystem,!GPP]
         {
             name = The Badlands
             icon = ContractPacks/Tourism/Icons/Kerbal
@@ -160,7 +161,7 @@ CONTRACT_TYPE
             hidden = @/selectedWaypoint != 3
         }
 
-        WAYPOINT
+        WAYPOINT:NEEDS[!RealSolarSystem,!GPP]
         {
             name = The Northern Mountains
             icon = ContractPacks/Tourism/Icons/Kerbal
@@ -173,7 +174,7 @@ CONTRACT_TYPE
             hidden = @/selectedWaypoint != 4
         }
 
-        WAYPOINT
+        WAYPOINT:NEEDS[!RealSolarSystem,!GPP]
         {
             name = K2
             icon = ContractPacks/Tourism/Icons/Kerbal
@@ -186,7 +187,7 @@ CONTRACT_TYPE
             hidden = @/selectedWaypoint != 5
         }
 
-        WAYPOINT
+        WAYPOINT:NEEDS[!RealSolarSystem,!GPP]
         {
             name = The Southern Mountains
             icon = ContractPacks/Tourism/Icons/Kerbal
@@ -199,7 +200,7 @@ CONTRACT_TYPE
             hidden = @/selectedWaypoint != 6
         }
 
-        WAYPOINT
+        WAYPOINT:NEEDS[!RealSolarSystem,!GPP]
         {
             name = The Impact Crater
             icon = ContractPacks/Tourism/Icons/Kerbal
@@ -211,6 +212,220 @@ CONTRACT_TYPE
 
             hidden = @/selectedWaypoint != 7
         }
+		
+		// #################
+		// RealSolarSystem waypoints
+		WAYPOINT:NEEDS[RealSolarSystem]
+		{
+			name = Mount Everest
+            icon = ContractPacks/Tourism/Icons/Kerbal
+
+            // The location
+            latitude = 27.988056
+            longitude = 86.925278
+            altitude = @/targetBody.AtmosphereAltitude()
+
+            hidden = @/selectedWaypoint != 2
+		}
+		
+		WAYPOINT:NEEDS[RealSolarSystem]
+		{
+			name = Aconcagua
+            icon = ContractPacks/Tourism/Icons/Kerbal
+
+            // The location
+            latitude = -32.653431 
+            longitude = -70.011083
+            altitude = @/targetBody.AtmosphereAltitude()
+
+            hidden = @/selectedWaypoint != 3
+		}
+		
+		WAYPOINT:NEEDS[RealSolarSystem]
+		{
+			name = Mount Kilimanjaro
+            icon = ContractPacks/Tourism/Icons/Kerbal
+
+            // The location
+            latitude = -3.075833
+            longitude = 37.353333
+            altitude = @/targetBody.AtmosphereAltitude()
+
+            hidden = @/selectedWaypoint != 4
+		}
+		
+		WAYPOINT:NEEDS[RealSolarSystem]
+		{
+			name = Denali (Mount McKinley)
+            icon = ContractPacks/Tourism/Icons/Kerbal
+
+            // The location
+            latitude = 63.0695 
+            longitude = -151.0074
+            altitude = @/targetBody.AtmosphereAltitude()
+
+            hidden = @/selectedWaypoint != 5
+		}
+		
+		WAYPOINT:NEEDS[RealSolarSystem]
+		{
+			name = Mont Blanc
+            icon = ContractPacks/Tourism/Icons/Kerbal
+
+            // The location
+            latitude = 45.833611 
+            longitude = 6.865
+            altitude = @/targetBody.AtmosphereAltitude()
+
+            hidden = @/selectedWaypoint != 6
+		}
+		
+		WAYPOINT:NEEDS[RealSolarSystem]
+		{
+			name = Bikini Atoll
+            icon = ContractPacks/Tourism/Icons/Kerbal
+
+            // The location
+            latitude = 11.583333 
+            longitude = 165.383333
+            altitude = @/targetBody.AtmosphereAltitude()
+
+            hidden = @/selectedWaypoint != 7
+		}
+		
+		WAYPOINT:NEEDS[RealSolarSystem]
+		{
+			name = Nile Delta
+            icon = ContractPacks/Tourism/Icons/Kerbal
+
+            // The location
+            latitude = 31.2
+            longitude = 29.916667
+            altitude = @/targetBody.AtmosphereAltitude()
+
+            hidden = @/selectedWaypoint != 8
+		}
+		
+		WAYPOINT:NEEDS[RealSolarSystem]
+		{
+			name = Grand Canyon
+            icon = ContractPacks/Tourism/Icons/Kerbal
+
+            // The location
+            latitude = 36.3
+            longitude = -112.6
+            altitude = @/targetBody.AtmosphereAltitude()
+
+            hidden = @/selectedWaypoint != 9
+		}
+		
+		WAYPOINT:NEEDS[RealSolarSystem]
+		{
+			name = Mouth of the Amazon
+            icon = ContractPacks/Tourism/Icons/Kerbal
+
+            // The location
+            latitude = 0.75 
+            longitude = -50.0
+            altitude = @/targetBody.AtmosphereAltitude()
+
+            hidden = @/selectedWaypoint != 10
+		}
+		
+		
+		
+		// #################
+		// GPP waypoints
+		WAYPOINT:NEEDS[GPP]
+		{
+			name = Point Spetses
+            icon = ContractPacks/Tourism/Icons/Kerbal
+
+            // The location
+            latitude = 51.5
+            longitude = 159.1
+            altitude = @/targetBody.AtmosphereAltitude()
+
+            hidden = @/selectedWaypoint != 2
+		}
+		
+		WAYPOINT:NEEDS[GPP]
+		{
+			name = Kerbonaut's Hope
+            icon = ContractPacks/Tourism/Icons/Kerbal
+
+            // The location
+            latitude = 42.5959
+            longitude = -31.6
+            altitude = @/targetBody.AtmosphereAltitude()
+
+            hidden = @/selectedWaypoint != 3
+		}
+		
+		WAYPOINT:NEEDS[GPP]
+		{
+			name = Northern Valley
+            icon = ContractPacks/Tourism/Icons/Kerbal
+
+            // The location
+            latitude = 15.5316
+            longitude = -32.0254
+            altitude = @/targetBody.AtmosphereAltitude()
+
+            hidden = @/selectedWaypoint != 4
+		}
+		
+		WAYPOINT:NEEDS[GPP]
+		{
+			name = Rooks Glory
+            icon = ContractPacks/Tourism/Icons/Kerbal
+
+            // The location
+            latitude = 0
+            longitude = 36.048
+            altitude = @/targetBody.AtmosphereAltitude()
+
+            hidden = @/selectedWaypoint != 5
+		}
+		
+		WAYPOINT:NEEDS[GPP]
+		{
+			name = DomRok
+            icon = ContractPacks/Tourism/Icons/Kerbal
+
+            // The location
+            latitude = -7.35
+            longitude = -114.815
+            altitude = @/targetBody.AtmosphereAltitude()
+
+            hidden = @/selectedWaypoint != 6
+		}
+		
+		WAYPOINT:NEEDS[GPP]
+		{
+			name = Broken Arrow
+            icon = ContractPacks/Tourism/Icons/Kerbal
+
+            // The location
+            latitude = -18
+            longitude = 116.5
+            altitude = @/targetBody.AtmosphereAltitude()
+
+            hidden = @/selectedWaypoint != 7
+		}
+		
+		WAYPOINT:NEEDS[GPP]
+		{
+			name = Mount Maximus
+            icon = ContractPacks/Tourism/Icons/Kerbal
+
+            // The location
+            latitude = 6.5506
+            longitude = 167.8741
+            altitude = @/targetBody.AtmosphereAltitude()
+
+            hidden = @/selectedWaypoint != 8
+		}
     }
 
     BEHAVIOUR


### PR DESCRIPTION
The named waypoints (e.g. Badlands, Great Desert) are only suitable for Kerbin. 

I added MM conditions to replace them with GPP or RealSolarSystem specific waypoints if one of those mods is present.